### PR TITLE
[#1] fix: update upsertFromDTO to handle sync & hash

### DIFF
--- a/app/Models/Content.php
+++ b/app/Models/Content.php
@@ -26,6 +26,8 @@ class Content extends Model
         'freshness_score',
         'engagement_score',
         'final_score',
+        'content_hash',
+        'synced_at',
     ];
 
     protected $casts = [

--- a/tests/Feature/Repositories/ContentRepositoryTest.php
+++ b/tests/Feature/Repositories/ContentRepositoryTest.php
@@ -8,6 +8,7 @@ use App\DTO\ScoreDTO;
 use App\DTO\VideoMetricsDTO;
 use App\Models\Content;
 use App\Repositories\ContentRepository;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -79,4 +80,101 @@ class ContentRepositoryTest extends TestCase
         $this->assertEquals(5.0, (float)$c->engagement_score);
         $this->assertEquals(16.0, (float)$c->final_score);
     }
+
+    #[Test]
+    public function upsert_sets_content_hash_and_synced_at_on_create(): void
+    {
+        $repo = new ContentRepository();
+
+        $dto = new ContentDTO(
+            provider: 'json_provider',
+            providerItemId: 'x1',
+            title: 'T',
+            type: 'video',
+            publishedAt: now(),
+            tags: [],
+            metrics: new VideoMetricsDTO(views: 1, likes: 1, durationSeconds: 1)
+        );
+
+        $c = $repo->upsertFromDTO($dto);
+        $this->assertNotNull($c->synced_at);
+        $this->assertNotNull($c->content_hash);
+    }
+
+    #[Test]
+    public function unchanged_payload_keeps_hash_and_bumps_synced(): void
+    {
+        $repo = new ContentRepository();
+
+        $dto = new ContentDTO(
+            provider: 'json_provider',
+            providerItemId: 'v-sync-1',
+            title: 'Same Title',
+            type: 'video',
+            publishedAt: now(),
+            tags: ['php','laravel'],
+            metrics: new VideoMetricsDTO(views: 100, likes: 10, durationSeconds: 60)
+        );
+
+        $created = $repo->upsertFromDTO($dto)->fresh();
+        $originalHash      = $created->content_hash;
+        $originalSyncedAt  = $created->synced_at;
+
+        Carbon::setTestNow(now()->addMinute());
+        $again = $repo->upsertFromDTO($dto)->fresh();
+
+        $this->assertSame($created->id, $again->id);
+        $this->assertSame($originalHash, $again->content_hash);
+
+        $this->assertTrue($again->synced_at->gt($originalSyncedAt));
+
+        Carbon::setTestNow();
+    }
+
+    #[Test]
+    public function changed_payload_updates_fields_and_hash_and_bumps_synced(): void
+    {
+        $repo = new ContentRepository();
+
+        $dto1 = new ContentDTO(
+            provider: 'json_provider',
+            providerItemId: 'v-sync-2',
+            title: 'Old',
+            type: 'video',
+            publishedAt: now(),
+            tags: ['a'],
+            metrics: new VideoMetricsDTO(views: 1, likes: 1, durationSeconds: 10)
+        );
+
+        $created = $repo->upsertFromDTO($dto1)->fresh();
+        $oldHash       = $created->content_hash;
+        $oldSyncedAt   = $created->synced_at;
+
+        Carbon::setTestNow(now()->addSeconds(2));
+
+        $dto2 = new ContentDTO(
+            provider: 'json_provider',
+            providerItemId: 'v-sync-2',
+            title: 'New', // changed
+            type: 'video',
+            publishedAt: $dto1->publishedAt,
+            tags: ['a','b'], // changed
+            metrics: new VideoMetricsDTO(views: 2, likes: 3, durationSeconds: 12) // changed
+        );
+
+        $updated = $repo->upsertFromDTO($dto2)->fresh();
+
+        $this->assertSame($created->id, $updated->id);
+
+        $this->assertSame('New', $updated->title);
+        $this->assertSame(['a','b'], $updated->tags);
+        $this->assertSame(2, $updated->metrics['views']);
+
+        $this->assertNotSame($oldHash, $updated->content_hash);
+
+        $this->assertTrue($updated->synced_at->gte($oldSyncedAt));
+
+        Carbon::setTestNow();
+    }
+
 }


### PR DESCRIPTION
### Summary
- Extended `upsertFromDTO` to handle content_hash and synced_at
- Added tests for sync & hash behavior

### Related issue
Closes #1
